### PR TITLE
Remove secret key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022]
-        python-version: ['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 name: build
 on: [push]
 jobs:
-  general:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12]
-        python-version: ['3.8.12', '3.9.7', '3.10.0']
+        os: [macos-11, macos-12, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022]
+        python-version: ['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: [macos-latest, ubuntu-latest]
+        python-version: ['3.7', '3']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022]
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Random password generation and diceware password generation is a provided utilit
 random passwords and diceware passwords.
 
 ## Building
+The minimum python version is 3.7 and sqlite3 is required (installed by default on MacOS).
+
 Run `make` and follow the instructions printed out.
 
 ## Cryptographic Implementation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-keyring >= 23.5.0
 pycryptodome >= 3.14.1
 passlib >= 1.7.4
 pyperclip >= 1.8.2

--- a/src/crypt_utils.py
+++ b/src/crypt_utils.py
@@ -1,5 +1,4 @@
 import base64
-import secrets
 
 from passlib.hash import pbkdf2_sha256
 
@@ -14,32 +13,17 @@ def base64_string(_byte_string):
     return base64.b64encode(_byte_string, b'./').decode('utf-8').replace('=', '')
 
 
-def generate_secret_key():
-    secret_key_bytes = secrets.token_bytes(constants.SALT_SIZE)
-    return base64_string(secret_key_bytes)
-
-
-def generate_hash(secret_key, main_key):
+def generate_hash(main_key):
     pair = pbkdf2_sha256.using(rounds=constants.HASH_ROUNDS, salt_size=constants.SALT_SIZE).hash(main_key)
     salt = pair.split('$')[3]
     hashed = pair.split('$')[4]
-    key = combine_keys(secret_key, hashed)
-    return key, salt
+    return hashed, salt
 
 
-def combine_keys(secret_key, main_key):
-    secret_key_bytes = byte_string(secret_key)
-    main_key_bytes = byte_string(main_key)
-    combined_key_bytes = bytearray(constants.SALT_SIZE)
-    for i in range(constants.SALT_SIZE):
-        combined_key_bytes[i] = secret_key_bytes[i] ^ main_key_bytes[i]
-    return base64_string(combined_key_bytes)
-
-
-def hash_with_salt(secret_key, main_key, salt):
+def hash_with_salt(main_key, salt):
     salt_bytes = byte_string(salt)
     pair = pbkdf2_sha256.using(rounds=constants.HASH_ROUNDS, salt=salt_bytes).hash(main_key)
-    return combine_keys(secret_key, pair.split('$')[4])
+    return pair.split('$')[4]
 
 
 def zero_pad(string):

--- a/tst/test_crypt_utils.py
+++ b/tst/test_crypt_utils.py
@@ -1,33 +1,25 @@
+import random
+import string
+
 from src import crypt_utils
+
+
+def _random(length=8):
+    return ''.join(random.choice(string.ascii_uppercase) for _ in range(length))
 
 
 class TestCryptUtils:
     def setup_method(self):
-        self.main_key = crypt_utils.generate_secret_key()
-        self.secret_key = crypt_utils.generate_secret_key()
-
-    def test_key_generation_random(self):
-        assert self.main_key != self.secret_key
-
-    def test_temporal_key_combination(self):
-        c1 = crypt_utils.combine_keys(self.main_key, self.secret_key)
-        c2 = crypt_utils.combine_keys(self.main_key, self.secret_key)
-        assert c1 == c2
-
-    def test_commutative_key_combination(self):
-        c1 = crypt_utils.combine_keys(self.main_key, self.secret_key)
-        c2 = crypt_utils.combine_keys(self.secret_key, self.main_key)
-        assert c1 == c2
+        self.main_key = _random()
 
     def test_random_salt(self):
-        auth_key_1, auth_salt_1 = crypt_utils.generate_hash(self.secret_key, self.main_key)
-        auth_key_2, auth_salt_2 = crypt_utils.generate_hash(self.secret_key, self.main_key)
+        auth_key_1, auth_salt_1 = crypt_utils.generate_hash(self.main_key)
+        auth_key_2, auth_salt_2 = crypt_utils.generate_hash(self.main_key)
         assert auth_key_1 != auth_key_2
         assert auth_salt_1 != auth_salt_2
 
     def test_password_hash(self):
-        auth_key, auth_salt = crypt_utils.generate_hash(self.secret_key, self.main_key)
+        auth_key, auth_salt = crypt_utils.generate_hash(self.main_key)
         assert auth_key != self.main_key
-        assert auth_key != self.secret_key
-        new_auth_key = crypt_utils.hash_with_salt(self.secret_key, self.main_key, auth_salt)
+        new_auth_key = crypt_utils.hash_with_salt(self.main_key, auth_salt)
         assert new_auth_key == auth_key

--- a/tst/test_vaults.py
+++ b/tst/test_vaults.py
@@ -15,7 +15,7 @@ def _random(length=8):
 class BaseTestVaults:
     def setup_method(self):
         self.username = _random()
-        self.crypt_key = crypt_utils.generate_secret_key()
+        self.crypt_key = crypt_utils.generate_hash(_random())[0]
         self.vaults = Vaults(self.username, Connection(), self.crypt_key)
         assert len(self.vaults.get_vault_names()) == 0
         self.vaults.add_vault('name-1', 'description-1', 'password-1')
@@ -118,7 +118,7 @@ class TestEditVaultPassword(BaseTestVaults):
 class TestException:
     def setup_method(self):
         self.username = _random()
-        self.crypt_key = crypt_utils.generate_secret_key()
+        self.crypt_key = crypt_utils.generate_hash(_random())[0]
         self.vaults = Vaults(self.username, Connection(), self.crypt_key)
         self.vaults.add_vault('name', 'description', 'password')
 


### PR DESCRIPTION
Since the database is local, the secret key doesn't provide too much value since it's local too. Removing the secret key makes this work on all operating systems since the dependency for the secret key only really worked on macOS.